### PR TITLE
Add notebook to list download scripts

### DIFF
--- a/list_download_scripts.ipynb
+++ b/list_download_scripts.ipynb
@@ -1,0 +1,28 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efec6b20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "from pathlib import Path\n",
+    "\n",
+    "pattern = \"/Workspace/Users/*/*/utilities/downloader.sh\"\n",
+    "paths = glob.glob(pattern)\n",
+    "folders = sorted({Path(p).parts[4] for p in paths})\n",
+    "print(folders)\n",
+    "\n",
+    "try:\n",
+    "    dbutils.jobs.taskValues.set(key=\"download_folders\", value=folders, overwrite=True)\n",
+    "except Exception as e:\n",
+    "    print(f\"Could not set task values: {e}\")\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `list_download_scripts.ipynb` for discovering downloader scripts within `/Workspace/Users/<user>/<folder>/utilities`
- set the discovered folders as Databricks task values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb8eb4dac8329b64375cc6f3023e2